### PR TITLE
Fix wemeet launch failed

### DIFF
--- a/bucket/we-meet.json
+++ b/bucket/we-meet.json
@@ -9,7 +9,7 @@
     "hash": "md5:dc4d3ae9e357a0b348759a6aca324bc2",
     "installer": {
         "script": [
-            "Get-Item \"$dir\\`$_?_\" | Rename-Item -NewName \"$version\"",
+            "Get-Item \"$dir\\`$_*_\" | Rename-Item -NewName \"$version\"",
             "Move-Item \"$dir\\wemeetapp_new.exe\" \"$dir\\WeMeet.exe\"",
             "Remove-Item -R -Path \"$dir\\`$WINDIR\",\"$dir\\`$PLUGINSDIR\",\"$dir\\`$TEMP\",\"$dir\\wemeetapp.exe\""
         ]


### PR DESCRIPTION
新版腾讯会议子文件夹名称变成了$_10_，原来的正则表达无法正确匹配导致重命名失败，修改为$_*_，匹配任意字符串，应该不会造成其他问题。

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
