### PR TITLE
sunlogin: Fix a download issue

### DIFF
--- a/bucket/sunlogin.json
+++ b/bucket/sunlogin.json
@@ -7,12 +7,24 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://down.oray.com/sunlogin/windows/SunloginClient_15.3.2.62919_x64.exe#/Sunlogin.exe",
-            "hash": "md5:d87559509270c4baad371110e9b65354"
+            "url": "https://down.oray.com/sunlogin/windows/SunloginClient_15.3.2.62919_x64.exe",
+            "hash": "md5:d87559509270c4baad371110e9b65354",
+            "shortcuts": [
+                [
+                    "SunloginClient_15.3.2.62919_x64.exe",
+                    "Sunlogin"
+                ]
+            ]
         },
         "32bit": {
-            "url": "https://down.oray.com/sunlogin/windows/SunloginClient_15.3.2.62919.exe#/Sunlogin.exe",
-            "hash": "md5:16c0c8e54baf8d27dd99faebc656ca6d"
+            "url": "https://down.oray.com/sunlogin/windows/SunloginClient_15.3.2.62919.exe",
+            "hash": "md5:16c0c8e54baf8d27dd99faebc656ca6d",
+            "shortcuts": [
+                [
+                    "SunloginClient_15.3.2.62919.exe",
+                    "Sunlogin"
+                ]
+            ]
         }
     },
     "installer": {
@@ -22,12 +34,6 @@
             "New-ItemProperty -Path $path -Name \"${version}_IsRunSeted\" -Value \"1\" -PropertyType String -ErrorAction SilentlyContinue"
         ]
     },
-    "shortcuts": [
-        [
-            "Sunlogin.exe",
-            "Sunlogin"
-        ]
-    ],
     "checkver": {
         "url": "https://client-api.oray.com/softwares/SUNLOGIN_X_WINDOWS?x64=1",
         "jp": "$.downloadurl",
@@ -36,18 +42,30 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://down.oray.com/sunlogin/windows/SunloginClient_$version_$matchArch.exe#/Sunlogin.exe",
+                "url": "https://down.oray.com/sunlogin/windows/SunloginClient_$version_$matchArch.exe",
                 "hash": {
                     "url": "https://client-api.oray.com/softwares/SUNLOGIN_X_WINDOWS?x64=1",
                     "jp": "$.md5"
-                }
+                },
+                "shortcuts": [
+                    [
+                        "SunloginClient_$version_$matchArch.exe",
+                        "Sunlogin"
+                    ]
+                ]
             },
             "32bit": {
-                "url": "https://down.oray.com/sunlogin/windows/SunloginClient_$version.exe#/Sunlogin.exe",
+                "url": "https://down.oray.com/sunlogin/windows/SunloginClient_$version.exe",
                 "hash": {
                     "url": "https://client-api.oray.com/softwares/SUNLOGIN_X_WINDOWS?x64=0",
                     "jp": "$.md5"
-                }
+                },
+                "shortcuts": [
+                    [
+                        "SunloginClient_$version.exe",
+                        "Sunlogin"
+                    ]
+                ]
             }
         }
     }


### PR DESCRIPTION
This issue is actually caused by that the *not very well stripped* `Referer` header being rejected by the upstream application provider. 

Yet, this PR does not seek to resolve the root cause, instead it just circumvent the issue by removing the segment in the download URL, which in turn let the `Referer` being properly stripped. 