### PR TITLE
dingtalk: Check the version via 302 responses

### DIFF
--- a/bucket/dingtalk.json
+++ b/bucket/dingtalk.json
@@ -1,13 +1,13 @@
 {
-    "version": "6.3.26.1229102",
+    "version": "7.8.8.250704005",
     "description": "钉钉",
     "homepage": "https://www.dingtalk.com/",
     "license": {
         "identifier": "Freeware"
     },
-    "url": "https://dtapp-pub.dingtalk.com/dingtalk-desktop/win_installer/Release/DingTalk_v6.3.26.1229102.exe#/dl.7z",
+    "url": "https://dtapp-pub.dingtalk.com/dingtalk-desktop/win_installer/Release/overseas/DingTalk_v7.8.8.250704005.exe#/dl.7z",
     "pre_install": "Remove-Item -R -Path \"$dir\\uninst.exe.nsis\",\"$dir\\`$PLUGINSDIR\"",
-    "hash": "997567adbe1680a8ae32d228c6bbfef5e3dc6a382e2cff97bc5146c02722dc11",
+    "hash": "b084339cb4d437a6155b5a626d46b3c059ee877b79d00ccc221b3ffda21635ab",
     "shortcuts": [
         [
             "DingtalkLauncher.exe",
@@ -15,10 +15,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://page.dingtalk.com/wow/dingtalk/act/en-download",
+        "script": [
+            "$i = Invoke-WebRequest 'https://www.dingtalk.com/win/d/qd=oversea' -MaximumRedirection 0 -ErrorAction Ignore",
+            "$i.Headers.Location"
+        ],
         "regex": "DingTalk_v([\\d\\.]+)\\.exe"
     },
     "autoupdate": {
-        "url": "https://dtapp-pub.dingtalk.com/dingtalk-desktop/win_installer/Release/DingTalk_v$version.exe#/dl.7z"
+        "url": "https://dtapp-pub.dingtalk.com/dingtalk-desktop/win_installer/Release/overseas/DingTalk_v$version.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
This change uses a new strategy to check the correct version via a 302 reponse from https://www.dingtalk.com/win/d/qd=oversea