### PR TITLE
todesk: update hash for 4.6.0.3

### DIFF
--- a/bucket/todesk.json
+++ b/bucket/todesk.json
@@ -7,7 +7,7 @@
         "url": "https://www.todesk.com/pricing.html"
     },
     "url": "https://dl.todesk.com/windows/ToDesk_Setup.exe#/dl.7z",
-    "hash": "57b8f33953401a80bfb220e55b73957293a186589d26bc3c5f18b8de84814d5e",
+    "hash": "4055f47da713ea1971eb0421489b14bb06aa7b444835406ccbb568e7b794281c",
     "pre_install": [
         "Expand-7ZipArchive \"$dir\\app64.7z\" \"$dir\"",
         "Remove-Item -R -Path \"$dir\\`$PLUGINSDIR\"",


### PR DESCRIPTION
The installer at the upstream URL has changed and the previous hash no longer matches.

Old hash:
`57b8f33953401a80bfb220e55b73957293a186589d26bc3c5f18b8de84814d5e`

New hash:
`4055f47da713ea1971eb0421489b14bb06aa7b444835406ccbb568e7b794281c`

This fixes the Scoop installation failure:
`Hash check failed`
